### PR TITLE
#xxx/stale workflow improvements

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   stale:
-    env:
-      repo-token: ${{secrets.GITHUB_TOKEN}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,12 +15,12 @@ jobs:
       - uses: actions/stale@v9
         with:
           # stale and delete issues
-          stale-issue-message: '🤖 Meep Morp! This Issue is now marked as stale because there has been no activity for a while. \n\nIt will be deleted in 7 days unless there are new contributions.'
+          stale-issue-message: '🤖 Meep Morp! This Issue is now marked as stale because there has been no activity for a while.<br><br>It will be deleted in 7 days unless there are new contributions.'
           close-issue-message: '🤖 Meep Morp :( This Issue has been closed because it was stale for 7 days.'
           days-before-issue-stale: 21
           days-before-issue-close: 7
 
           # stale pull requests
-          stale-pr-message: '🤖 Meep Morp! This PR is now marked as stale because there has been no activity for a while. \n\nPlease guarantee this is still a relevant PR.'
+          stale-pr-message: '🤖 Meep Morp! This PR is now marked as stale because there has been no activity for a while.<br><br>Please guarantee this is still a relevant PR.'
           days-before-pr-stale: 14
           days-before-pr-close: -1 # Applying a negative value means the pr will not be closed and is simply being marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
           # stale and delete issues
           stale-issue-message: '🤖 Meep Morp! This Issue is now marked as stale because there has been no activity for a while. \n\nIt will be deleted in 7 days unless there are new contributions.'
           close-issue-message: '🤖 Meep Morp :( This Issue has been closed because it was stale for 7 days.'


### PR DESCRIPTION
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review on my code
- [ ] I have made corresponding changes to the documentation (if any were needed)
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and previously existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description

**Closes #XXX**  
Basic improvements/cleanups on the stale issue/PR workflow.

### Files changed

`.github/workflows/stale.yml`:
- 799d38b Removed an invalid action input.
  - Is causing the `Unexpected input(s) 'GITHUB_TOKEN'` warning in the workflow runs ([example](https://github.com/enBloc-org/kindly/actions/runs/9295893813)).
- 4b9b1dd Removed an unnecessary environment variable.
  - `actions/stale` already sets `repo-token` with the token by default ([doc](https://github.com/actions/stale?tab=readme-ov-file#repo-token)).
- bff49b2 Replaced `\n` with `<br>` line breaks for the messages.
  - These are currently not being shown as intended ([issue](https://github.com/enBloc-org/kindly/issues/97#issuecomment-2062859252) and [PR](https://github.com/enBloc-org/kindly/pull/187#issuecomment-2097271910) examples), due to not being MD line breaks. 

# Tests

The messages show as expected in my fork, as can be seen in this [issue comment](https://github.com/mnixo/kindly/issues/1#issuecomment-2139415012) and [PR comment](https://github.com/mnixo/kindly/pull/2#issuecomment-2139426978).
